### PR TITLE
Provide helpful errors on JSON.parse exception

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "email": "hughskennedy@gmail.com",
     "url": "http://hughsk.io/"
   },
-  "dependencies": {},
+  "dependencies": {
+    "json-parse-helpfulerror": "^1.0.3"
+  },
   "devDependencies": {
     "deep-equal": "^0.2.1",
     "tap-spec": "^0.2.0",


### PR DESCRIPTION
The normal exception that `JSON.parse` throws is not very helpful. So if we tried to open an invalid package.json, you won't know which file caused the exception and why the parse failed.

This commit extends the exception message with the file name that we tried to load and clues to the location of the error in the JSON (using the same module that npm uses, called `json-parse-helpfulerror`). The performance should pretty much be the same, since it first tries to use `JSON.parse` and only if it throws, it analyzes the cause.
